### PR TITLE
use exportgraphics function for matlabs from 2020a

### DIFF
--- a/export_fig.m
+++ b/export_fig.m
@@ -1,8 +1,10 @@
 function export_fig(varargin)
 matlabversion=datevec(version('-date'));
-if matlabversion(1)>=2014
-export_fig_2014(varargin{:});    
+if matlabversion(1)>=2020
+    exportgraphics(gcf, [varargin{1} '.pdf']) % with all respect to export_fig and previous efforts of people to make it work, let's use the existing funtionality of Matlab for saving pdfs
+elseif matlabversion(1)>=2014
+    export_fig_2014(varargin{:});    
 else
-export_fig_2011(varargin{:});
+    export_fig_2011(varargin{:});
 end
 end


### PR DESCRIPTION
export_fig didn't render properly for ecg-spike analysis - I had non-transparent errorbars. For other analyses it worked well. Reinstalling ghostscript of an older version didn't help. Let switch to the existing Matlab functionality.